### PR TITLE
解决重启clash过程中tun设备配置偶尔失败的问题

### DIFF
--- a/tun_linux.go
+++ b/tun_linux.go
@@ -70,7 +70,7 @@ func init() {
 func open(name string) (int, error) {
 	fd, err := unix.Open(controlPath, unix.O_RDWR, 0)
 	if err != nil {
-		return -1, err
+		return -1, E.Cause(err, "open:", controlPath)
 	}
 
 	var ifr struct {
@@ -84,12 +84,12 @@ func open(name string) (int, error) {
 	_, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), unix.TUNSETIFF, uintptr(unsafe.Pointer(&ifr)))
 	if errno != 0 {
 		unix.Close(fd)
-		return -1, errno
+		return -1, E.Cause(errno, "ioctl")
 	}
 
 	if err = unix.SetNonblock(fd, true); err != nil {
 		unix.Close(fd)
-		return -1, err
+		return -1, E.Cause(err, "set nonblock")
 	}
 
 	return fd, nil
@@ -107,25 +107,25 @@ func (t *NativeTun) configure(tunLink netlink.Link) error {
 	if len(t.options.Inet4Address) > 0 {
 		for _, address := range t.options.Inet4Address {
 			addr4, _ := netlink.ParseAddr(address.String())
-			err = netlink.AddrAdd(tunLink, addr4)
+			err = netlink.AddrReplace(tunLink, addr4)
 			if err != nil {
-				return err
+				return E.Cause(err, "add inet4 addr:", address.String())
 			}
 		}
 	}
 	if len(t.options.Inet6Address) > 0 {
 		for _, address := range t.options.Inet6Address {
 			addr6, _ := netlink.ParseAddr(address.String())
-			err = netlink.AddrAdd(tunLink, addr6)
+			err = netlink.AddrReplace(tunLink, addr6)
 			if err != nil {
-				return err
+				return E.Cause(err, "add inet6 addr:", address.String())
 			}
 		}
 	}
 
 	err = netlink.LinkSetUp(tunLink)
 	if err != nil {
-		return err
+		return E.Cause(err, "link setup")
 	}
 
 	if t.options.TableIndex == 0 {
@@ -141,7 +141,7 @@ func (t *NativeTun) configure(tunLink netlink.Link) error {
 	err = t.setRoute(tunLink)
 	if err != nil {
 		_ = t.unsetRoute0(tunLink)
-		return err
+		return E.Cause(err, "set route")
 	}
 
 	err = t.unsetRules()
@@ -151,7 +151,7 @@ func (t *NativeTun) configure(tunLink netlink.Link) error {
 	err = t.setRules()
 	if err != nil {
 		_ = t.unsetRules()
-		return err
+		return E.Cause(err, "set rules")
 	}
 
 	if t.options.AutoRoute && runtime.GOOS == "android" {


### PR DESCRIPTION
在x86路由环境下clash重启过程中偶尔出现错误：Start TUN listening error: configure tun interface: file exists
问题来源如下
```
	if len(t.options.Inet4Address) > 0 {
		for _, address := range t.options.Inet4Address {
			addr4, _ := netlink.ParseAddr(address.String())
			err = netlink.AddrAdd(tunLink, addr4)
			if err != nil {
				return err
			}
		}
	}
```
netlink.AddrAdd不知为何地址已存在

此PR未对addr已存在原因做分析，仅将AddrAdd替换为AddrReplace，可绕过该问题
