### PR TITLE
fix: remove wrong check of OverrideAndroidVPN when creating android routing rules

### DIFF
--- a/tun_linux.go
+++ b/tun_linux.go
@@ -576,10 +576,8 @@ func (t *NativeTun) rules() []*netlink.Rule {
 		const protectedFromVPN = 0x20000
 		if p4 {
 			it = netlink.NewRule()
-			if t.options.InterfaceMonitor.OverrideAndroidVPN() {
-				it.Mark = protectedFromVPN
-				it.MarkSet = true
-			}
+			it.Mark = protectedFromVPN
+			it.MarkSet = true
 			it.Mask = protectedFromVPN
 			it.Priority = priority
 			it.Family = unix.AF_INET
@@ -589,10 +587,8 @@ func (t *NativeTun) rules() []*netlink.Rule {
 		}
 		if p6 {
 			it = netlink.NewRule()
-			if t.options.InterfaceMonitor.OverrideAndroidVPN() {
-				it.Mark = protectedFromVPN
-				it.MarkSet = true
-			}
+			it.Mark = protectedFromVPN
+			it.MarkSet = true
 			it.Mask = protectedFromVPN
 			it.Family = unix.AF_INET6
 			it.Priority = priority6


### PR DESCRIPTION
**Bug description:**

The iproute2 rule being created here is:
`9000: from all fwmark 0xY/0x20000 goto 9010`.
Its purpose is to control whether traffic that has been marked by `VPNService.protect` will bypass Mihomo.

According to the current code,
- When `OverrideAndroidVPN == true`, this rule is created as `9000: from all fwmark 0x20000/0x20000 goto 9010`, so
  - Traffic bypasses Mihomo when its `VpnProtect` bit is 1
  - Traffic goes into Mihomo for processing when its `VpnProtect` bit is 0
- When `OverrideAndroidVPN == false`, this rule is created as `9000: from all fwmark 0x0/0x20000 goto 9010`, meaning that 
  - Traffic bypasses Mihomo when its `VpnProtect` bit is 0
  - Traffic goes into Mihomo for processing when its `VpnProtect` bit is 1

> **However, the logic here is wrong**

**In fact, this rule should always be created as `9000: from all fwmark 0x20000/0x20000 goto 9010`, regardless of whether `OverrideAndroidVPN` is `true` or not**

The reason is: the design goal of `OverrideAndroidVPN` is to guide Mihomo whether or not to use Android VPN as an upstream NIC.

- If `OverrideAndroidVPN == true`, with`auto-detect-interface`, Mihomo automatically recognizes the Android VPN (tun0) as the upstream NIC, and all requests outbound from Mihomo are sent to tun0.
- If `OverrideAndroidVPN == false`, all requests outbound from Mihomo should bypass the Android VPN, and go directly to the primary NIC (e.g. wlan0).

So, anyway, by the design of this feature, there should not be a situation where traffic sent outbound by Android VPN is still received by Mihomo. In other words, any traffic marked with Android `VpnProtect` mark must bypass Mihomo, and other normal traffic must goes into Mihomo, no matter what the parameters are set to. This ensures that Mihomo can always receives and processes traffic properly.

Current logic leads to the bug that, when `OverrideAndroidVPN` is set to `false`, all network traffic will first bypasses Mihomo and goes to the Android VPN for processing, then directly goes into the primary NIC (e.g., wlan0). Mihomo is unable to receive any of the traffic. This is obviously problematic, I think.