### PR TITLE
Fix dirty Address Family block

### DIFF
--- a/stack_system.go
+++ b/stack_system.go
@@ -713,7 +713,7 @@ func (s *System) rejectIPv4WithICMP(ipHdr header.IPv4, code header.ICMPv4Code) e
 	icmpHdr.SetChecksum(header.ICMPv4Checksum(icmpHdr[:header.ICMPv4MinimumSize], checksum.Checksum(ipHdr.Payload(), 0)))
 	copy(icmpHdr.Payload(), payload)
 	if PacketOffset > 0 {
-		newPacket.ExtendHeader(PacketOffset)[3] = syscall.AF_INET
+		PacketFillHeader(newPacket.ExtendHeader(PacketOffset), header.IPv4Version)
 	} else {
 		newPacket.Advance(-s.frontHeadroom)
 	}


### PR DESCRIPTION
Hi! This PR fixes the issue that I described here: https://github.com/apernet/sing-tun/pull/1

As I see, you have ported commit with the fix from the upstream:
https://github.com/MetaCubeX/sing-tun/commit/53dbe7b5dfd83ff15d22b820163cd852e8697342#diff-f119dd1fba983f93a4366d1333d07893ecf14d42f6941d271ad956bc1b574f6d

However, there is still one place where the buffer is not cleared before writing Address Family.