### PR TITLE
Fix DNS not revert while close tun

### DIFF
--- a/tun_linux.go
+++ b/tun_linux.go
@@ -438,6 +438,7 @@ func (t *NativeTun) Close() error {
 	if t.interfaceCallback != nil {
 		t.options.InterfaceMonitor.UnregisterCallback(t.interfaceCallback)
 	}
+	t.unsetSearchDomainForSystemdResolved()
 	t.unsetAddresses()
 	return E.Errors(t.unsetRoute(), t.unsetRules(), common.Close(common.PtrOrNil(t.tunFile)))
 }
@@ -1059,4 +1060,18 @@ func (t *NativeTun) setSearchDomainForSystemdResolved() {
 		_ = shell.Exec(ctlPath, "default-route", t.options.Name, "true").Run()
 		_ = shell.Exec(ctlPath, append([]string{"dns", t.options.Name}, common.Map(dnsServer, netip.Addr.String)...)...).Run()
 	}()
+}
+
+func (t *NativeTun) unsetSearchDomainForSystemdResolved() {
+    if t.options.EXP_DisableDNSHijack {
+        return
+    }
+    ctlPath, err := exec.LookPath("resolvectl")
+    if err != nil {
+        return
+    }
+    _ = shell.Exec(ctlPath, "revert", t.options.Name).Run()
+    if t.options.Logger != nil {
+        t.options.Logger.Debug("cleaned up DNS configuration for interface: ", t.options.Name)
+    }
 }


### PR DESCRIPTION
## Description
This PR adds `unsetSearchDomainForSystemdResolved()` to the `func (t *NativeTun) Close()` method.

## Motivation and Context
Previously, the initialization and teardown procedures were asymmetrical, causing DNS configurations to persist in `systemd-resolved` after the interface was closed.

**In `configure(tunLink)` (Setup):**
The initialization flow sets up the environment in the following order:
`setAddresses` -> `setRoute` -> `setRules` -> `setSearchDomainForSystemdResolved`

**In `Close()` (Teardown - Before Fix):**
The cleanup flow missed the corresponding step for systemd-resolved:
`unsetAddresses` -> `unsetRoute` -> `unsetRules` -> (Missing)

**In `Close()` (Teardown - After Fix):**
This PR ensures the cleanup logic mirrors the initialization:
`unsetSearchDomainForSystemdResolved` -> `unsetAddresses` -> `unsetRoute` -> `unsetRules`

## Changes
- Invoked `t.unsetSearchDomainForSystemdResolved()` in `func (t *NativeTun) Close()` to ensure proper DNS cleanup.