### PR TITLE
Stabilize Windows default route monitor selection

### DIFF
--- a/monitor_windows.go
+++ b/monitor_windows.go
@@ -16,6 +16,34 @@ import (
 // https://github.com/zerotier/ZeroTierOne/blob/1.8.6/osdep/WindowsEthernetTap.cpp#L994
 var zeroTierFakeGatewayIp = netip.MustParseAddr("25.255.255.254")
 
+type defaultRouteCandidate struct {
+	index  int
+	alias  string
+	metric uint32
+}
+
+func selectDefaultRouteCandidate(candidates []defaultRouteCandidate, previousIndex int) (defaultRouteCandidate, bool) {
+	if len(candidates) == 0 {
+		return defaultRouteCandidate{}, false
+	}
+
+	best := candidates[0]
+	bestIsPrevious := best.index == previousIndex
+
+	for _, candidate := range candidates[1:] {
+		switch {
+		case candidate.metric < best.metric:
+			best = candidate
+			bestIsPrevious = candidate.index == previousIndex
+		case candidate.metric == best.metric && !bestIsPrevious && candidate.index == previousIndex:
+			best = candidate
+			bestIsPrevious = true
+		}
+	}
+
+	return best, true
+}
+
 type networkUpdateMonitor struct {
 	routeListener     *winipcfg.RouteChangeCallback
 	interfaceListener *winipcfg.InterfaceChangeCallback
@@ -69,9 +97,12 @@ func (m *defaultInterfaceMonitor) checkUpdate() error {
 		return err
 	}
 
-	lowestMetric := ^uint32(0)
-	alias := ""
-	var index int
+	previousIndex := 0
+	if oldInterface := m.defaultInterface.Load(); oldInterface != nil {
+		previousIndex = oldInterface.Index
+	}
+
+	candidatesByIndex := map[int]defaultRouteCandidate{}
 
 	for _, row := range rows {
 		if row.DestinationPrefix.PrefixLength != 0 {
@@ -101,20 +132,30 @@ func (m *defaultInterfaceMonitor) checkUpdate() error {
 		}
 
 		metric := row.Metric + iface.Metric
-		if metric < lowestMetric {
-			lowestMetric = metric
-			alias = ifrow.Alias()
-			index = int(ifrow.InterfaceIndex)
+
+		candidate := defaultRouteCandidate{
+			index:  int(ifrow.InterfaceIndex),
+			alias:  ifrow.Alias(),
+			metric: metric,
+		}
+		if existing, ok := candidatesByIndex[candidate.index]; !ok || candidate.metric < existing.metric {
+			candidatesByIndex[candidate.index] = candidate
 		}
 	}
 
-	if alias == "" {
+	candidates := make([]defaultRouteCandidate, 0, len(candidatesByIndex))
+	for _, candidate := range candidatesByIndex {
+		candidates = append(candidates, candidate)
+	}
+
+	selected, ok := selectDefaultRouteCandidate(candidates, previousIndex)
+	if !ok {
 		return ErrNoRoute
 	}
 
-	newInterface, err := m.interfaceFinder.ByIndex(index)
+	newInterface, err := m.interfaceFinder.ByIndex(selected.index)
 	if err != nil {
-		return E.Cause(err, "find updated interface: ", alias)
+		return E.Cause(err, "find updated interface: ", selected.alias)
 	}
 	oldInterface := m.defaultInterface.Swap(newInterface)
 	if oldInterface != nil && oldInterface.Equals(*newInterface) {

--- a/monitor_windows_test.go
+++ b/monitor_windows_test.go
@@ -1,0 +1,39 @@
+package tun
+
+import "testing"
+
+func TestSelectDefaultRouteCandidatePrefersPreviousInterfaceOnMetricTie(t *testing.T) {
+	candidates := []defaultRouteCandidate{
+		{index: 36, alias: "WLAN", metric: 50},
+		{index: 37, alias: "WLAN 8", metric: 50},
+	}
+
+	selected, ok := selectDefaultRouteCandidate(candidates, 37)
+	if !ok {
+		t.Fatal("expected a selected candidate")
+	}
+	if selected.index != 37 {
+		t.Fatalf("expected previous interface 37 to be kept on metric tie, got %d", selected.index)
+	}
+}
+
+func TestSelectDefaultRouteCandidateSwitchesWhenMetricIsLower(t *testing.T) {
+	candidates := []defaultRouteCandidate{
+		{index: 36, alias: "WLAN", metric: 35},
+		{index: 37, alias: "WLAN 8", metric: 40},
+	}
+
+	selected, ok := selectDefaultRouteCandidate(candidates, 37)
+	if !ok {
+		t.Fatal("expected a selected candidate")
+	}
+	if selected.index != 36 {
+		t.Fatalf("expected lower-metric interface 36 to win, got %d", selected.index)
+	}
+}
+
+func TestSelectDefaultRouteCandidateReturnsFalseWhenEmpty(t *testing.T) {
+	if _, ok := selectDefaultRouteCandidate(nil, 0); ok {
+		t.Fatal("expected empty candidate list to return false")
+	}
+}


### PR DESCRIPTION
## Summary

On Windows, `defaultInterfaceMonitor.checkUpdate()` currently picks the lowest-metric default route by scanning the route table in order.

When multiple default routes from different interfaces have the same effective metric, route-table churn can make the selected interface oscillate between updates even though nothing materially changed.

This shows up downstream as repeated default-interface change notifications, which can trigger interface cache flushes and resolver connection resets in consumers such as `mihomo`.

## Changes

- keep only the best default-route candidate per interface
- when multiple interface candidates have the same effective metric, prefer the previously selected interface instead of switching arbitrarily
- still switch immediately when another interface has a strictly lower metric
- add unit tests covering tie retention, lower-metric switching, and empty candidate handling

## Validation

- `go test . -run TestSelectDefaultRouteCandidate -v`
- `go test .`

Tested locally on Windows 10 Pro build 26200.