### PR TITLE
fix: normalize ENOTSOCK/EBADF to os.ErrClosed on macOS TUN close

### DIFF
--- a/tun_darwin.go
+++ b/tun_darwin.go
@@ -1,6 +1,7 @@
 package tun
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"net/netip"
@@ -352,6 +353,9 @@ func (t *NativeTun) BatchRead() ([]*buf.Buffer, error) {
 			t.iovecs[k].buffer = nil
 		}
 		t.buffers = t.buffers[:0]
+		if errors.Is(errno, syscall.ENOTSOCK) || errors.Is(errno, syscall.EBADF) {
+			return nil, os.ErrClosed
+		}
 		return nil, errno
 	}
 	if n < 0 {
@@ -379,6 +383,9 @@ func (t *NativeTun) BatchWrite(buffers []*buf.Buffer) error {
 		for i := range buffers {
 			errno := rawfile.NonBlockingWriteIovec(t.tunFd, t.iovecsOutput[i].iovecs)
 			if errno != 0 {
+				if errors.Is(errno, syscall.ENOTSOCK) || errors.Is(errno, syscall.EBADF) {
+					return os.ErrClosed
+				}
 				return errno
 			}
 		}
@@ -393,6 +400,9 @@ func (t *NativeTun) BatchWrite(buffers []*buf.Buffer) error {
 		for n != len(buffers) {
 			sent, errno := rawfile.NonBlockingSendMMsg(t.tunFd, t.msgHdrsOutput[n:len(buffers)])
 			if errno != 0 {
+				if errors.Is(errno, syscall.ENOTSOCK) || errors.Is(errno, syscall.EBADF) {
+					return os.ErrClosed
+				}
 				return errno
 			}
 			n += sent


### PR DESCRIPTION
## Problem

On macOS, closing a utun device while batch reader/writer goroutines are active causes `recvmsg_x`/`sendmsg_x`/`writev` to return `ENOTSOCK` or `EBADF` (depending on timing). These are not recognized by `E.IsClosed()`, causing error spam in logs:

```
level=error msg="batch read packet: socket operation on non-socket"
level=error msg="batch read packet: bad file descriptor"
```

## Root cause

macOS utun is a **socket** (`socket(PF_SYSTEM, SOCK_DGRAM, SYSPROTO_CONTROL)`), unlike Linux TUN which is a **file** (`/dev/net/tun`). When the utun fd is closed, the errno values differ:

| Platform | TUN type | Errno on close |
|----------|----------|----------------|
| Linux | File | `EBADFD` (already handled in `tun_linux.go:90,248`) |
| macOS | Socket | `ENOTSOCK` + `EBADF` (not handled) |

## Fix

Normalize `ENOTSOCK` and `EBADF` to `os.ErrClosed` in `tun_darwin.go`, same pattern as `EBADFD` handling in `tun_linux.go`.

**3 locations** (all places that return raw errno from utun syscalls):
1. `BatchRead()` — `BlockingRecvMMsgUntilStopped` 
2. `BatchWrite()` non-MsgX path — `NonBlockingWriteIovec`
3. `BatchWrite()` MsgX path — `NonBlockingSendMMsg`

## Changes

- 1 file changed: `tun_darwin.go`
- Added `"errors"` import
- 10 lines added (3 error checks, same pattern as Linux)