### PR TITLE
[fix] nftables set Flush + OUTPUT NAT->fwmark (kernel 6.12+)

### DIFF
--- a/redirect_nftables.go
+++ b/redirect_nftables.go
@@ -66,10 +66,23 @@ func (r *autoRedirect) setupNFTables() error {
 				return err
 			}
 			r.nftablesCreateUnreachable(nft, table, chainOutput)
-			err = r.nftablesCreateRedirect(nft, table, chainOutput)
-			if err != nil {
-				return err
-			}
+			// Kernel 6.12+: No NAT redirect on OUTPUT. Mark for PREROUTING TPROXY.
+			nft.AddRule(&nftables.Rule{
+				Table: table,
+				Chain: chainOutput,
+				Exprs: []expr.Any{
+					&expr.Immediate{
+						Register: 1,
+						Data:     binaryutil.NativeEndian.PutUint32(r.tunOptions.AutoRedirectInputMark),
+					},
+					&expr.Meta{
+						Key:            expr.MetaKeyMARK,
+						Register:       1,
+						SourceRegister: true,
+					},
+					&expr.Counter{},
+				},
+			})
 			if len(r.tunOptions.Inet4LoopbackAddress) > 0 || len(r.tunOptions.Inet6LoopbackAddress) > 0 {
 				chainOutputRoute := nft.AddChain(&nftables.Chain{
 					Name:     "output_route",
@@ -97,17 +110,43 @@ func (r *autoRedirect) setupNFTables() error {
 			r.nftablesCreateUnreachable(nft, table, chainOutputUDP)
 			r.nftablesCreateMark(nft, table, chainOutputUDP)
 		} else {
-			err = r.nftablesCreateRedirect(nft, table, chainOutput, &expr.Meta{
-				Key:      expr.MetaKeyOIFNAME,
-				Register: 1,
-			}, &expr.Cmp{
-				Op:       expr.CmpOpEq,
-				Register: 1,
-				Data:     nftablesIfname(r.tunOptions.Name),
+			// Kernel 6.12+ rejects ChainTypeNAT on OUTPUT.
+			// Use fwmark: mark non-excluded traffic, let PREROUTING TPROXY catch it.
+			nft.AddRule(&nftables.Rule{
+				Table: table,
+				Chain: chainOutput,
+				Exprs: []expr.Any{
+					&expr.Meta{
+						Key:      expr.MetaKeyOIFNAME,
+						Register: 1,
+					},
+					&expr.Cmp{
+						Op:       expr.CmpOpEq,
+						Register: 1,
+						Data:     nftablesIfname(r.tunOptions.Name),
+					},
+					&expr.Counter{},
+					&expr.Verdict{
+						Kind: expr.VerdictReturn,
+					},
+				},
 			})
-			if err != nil {
-				return err
-			}
+			nft.AddRule(&nftables.Rule{
+				Table: table,
+				Chain: chainOutput,
+				Exprs: []expr.Any{
+					&expr.Immediate{
+						Register: 1,
+						Data:     binaryutil.NativeEndian.PutUint32(r.tunOptions.AutoRedirectInputMark),
+					},
+					&expr.Meta{
+						Key:            expr.MetaKeyMARK,
+						Register:       1,
+						SourceRegister: true,
+					},
+					&expr.Counter{},
+				},
+			})
 		}
 	}
 

--- a/redirect_nftables_exprs.go
+++ b/redirect_nftables_exprs.go
@@ -98,7 +98,15 @@ func nftablesCreateIPConst(
 	}
 	setElements := common.Map(addressList, func(addr netip.Addr) nftables.SetElement { return nftables.SetElement{Key: addr.AsSlice()} })
 	if id == 0 {
-		err := nft.AddSet(mySet, setElements)
+		err := nft.AddSet(mySet, nil)
+		if err != nil {
+			return nil, err
+		}
+		// commit set creation before adding elements (avoids EEXIST on kernel 6.12+)
+		if err := nft.Flush(); err != nil {
+			return nil, err
+		}
+		err = nft.SetAddElements(mySet, setElements)
 		if err != nil {
 			return nil, err
 		}
@@ -106,6 +114,10 @@ func nftablesCreateIPConst(
 	} else {
 		err := nft.AddSet(mySet, nil)
 		if err != nil {
+			return nil, err
+		}
+		// commit set creation before adding elements (avoids EEXIST on kernel 6.12+)
+		if err := nft.Flush(); err != nil {
 			return nil, err
 		}
 	}
@@ -196,7 +208,15 @@ func nftablesCreateIPSet(
 		mySet.Constant = true
 	}
 	if id == 0 {
-		err := nft.AddSet(mySet, setElements)
+		err := nft.AddSet(mySet, nil)
+		if err != nil {
+			return nil, err
+		}
+		// commit set creation before adding elements (avoids EEXIST on kernel 6.12+)
+		if err := nft.Flush(); err != nil {
+			return nil, err
+		}
+		err = nft.SetAddElements(mySet, setElements)
 		if err != nil {
 			return nil, err
 		}
@@ -206,6 +226,10 @@ func nftablesCreateIPSet(
 	} else {
 		err := nft.AddSet(mySet, nil)
 		if err != nil {
+			return nil, err
+		}
+		// Commit set creation before adding elements (avoids EEXIST on kernel 6.12+)
+		if err := nft.Flush(); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
## Problem

On Linux kernel 6.12+, nftables operations produce EEXIST and EINVAL:

1. **EEXIST**: `nftablesCreateIPSet()` and `nftablesCreateIPConst()` add elements to a set before the kernel has committed set creation
2. **EINVAL**: `ChainTypeNAT` on OUTPUT hook is rejected by kernel 6.12+

## Fix

1. Add explicit `nft.Flush()` after `AddSet()` and before `SetAddElements()` to commit set creation first
2. Replace `ChainTypeNAT` NAT redirect on OUTPUT with fwmark: mark non-excluded traffic with `AutoRedirectInputMark`, let PREROUTING TPROXY catch it

## Related Issues
- Closes MetaCubeX/mihomo#3001
- Companion fix: MetaCubeX/nftables#1 (netlink.Create value and chain attr order)

## Testing
- `go build -tags linux .` passes
- Tested with mihomo against real kernel 6.12.95 — auto-redirect starts without errors