### PR TITLE
fix: exclude wintun/tunnel virtual adapters from default interface detection on Windows

### DIFF
--- a/monitor_windows.go
+++ b/monitor_windows.go
@@ -2,6 +2,7 @@ package tun
 
 import (
 	"net/netip"
+	"strings"
 	"sync"
 
 	"github.com/metacubex/sing-tun/internal/winipcfg"
@@ -88,6 +89,15 @@ func (m *defaultInterfaceMonitor) checkUpdate() error {
 		}
 
 		if ifrow.Type == winipcfg.IfTypePropVirtual || ifrow.Type == winipcfg.IfTypeSoftwareLoopback {
+			continue
+		}
+
+		// Exclude wintun/tunnel virtual adapters.
+		// These register as IfType=6 (EthernetCSMACD) but are not physical NICs.
+		// Third-party wintun devices (e.g., OPPO Connect, ZeroTier) can interfere
+		// with TUN outbound routing if selected as the default interface.
+		desc := ifrow.Description()
+		if strings.Contains(desc, "Wintun") || strings.Contains(desc, "Tunnel") {
 			continue
 		}
 


### PR DESCRIPTION
## Problem

On Windows, third-party applications (e.g., OPPO Connect, ZeroTier) can create wintun virtual adapters that register as `IfType=6` (EthernetCSMACD) rather than `IfType=53` (PropVirtual). The current `checkUpdate()` filter in `monitor_windows.go` only excludes `IfTypePropVirtual` and `IfTypeSoftwareLoopback`, so these third-party wintun adapters can be selected as the default outbound interface.

When this happens, mihomo's DIRECT outbound traffic is routed through the third-party wintun adapter instead of the physical NIC, causing traffic to loop back into the TUN and triggering `reject loopback connection` errors — resulting in complete network failure.

## Root Cause

The wintun kernel driver (`wintun.sys`) registers all adapters as NDIS miniport with `IfType=6` (Ethernet). The existing type-based filter cannot distinguish them from real physical adapters:

```go
// current code - does not catch wintun devices
if ifrow.Type == winipcfg.IfTypePropVirtual || ifrow.Type == winipcfg.IfTypeSoftwareLoopback {
    continue
}
```

## Fix

Add a Description-based filter to exclude adapters whose `InterfaceDescription` contains "Wintun" or "Tunnel". These are virtual tunnel adapters and should never be selected as the default outbound interface.

## Reproduction

1. Install any application that creates a wintun adapter (e.g., OPPO Connect creates `ROOT\WINTUN\0000`)
2. Enable TUN mode with `auto-route: true`
3. All network traffic fails with `reject loopback connection` errors
4. Removing the third-party wintun device with `pnputil /remove-device` immediately resolves the issue

## Verification

- Tested on Windows 11 with OPPO Connect (O+Connect) installed
- OPPO Connect's wintun device: `ROOT\WINTUN\0000`, Description = "Wintun Userspace Tunnel", IfType=6, InterfaceMetric=5
- After applying this fix, the third-party wintun adapter is correctly excluded from default interface detection

## Related

- https://github.com/clash-verge-rev/clash-verge-rev/discussions/6712
