### PR TITLE
fix(darwin): reap DNS cache flush process

### DIFF
--- a/tun_darwin.go
+++ b/tun_darwin.go
@@ -444,5 +444,5 @@ func addRoute(destination netip.Prefix, gateway netip.Addr) error {
 }
 
 func flushDNSCache() {
-	shell.Exec("dscacheutil", "-flushcache").Start()
+	_ = shell.Exec("dscacheutil", "-flushcache").Run()
 }


### PR DESCRIPTION
## Why

On Darwin, `flushDNSCache` starts `dscacheutil -flushcache` with `Cmd.Start` and then discards the command. A successfully started `os/exec.Cmd` must be followed by `Wait`; otherwise completed children can remain as zombies until the long-running parent exits. Repeated TUN create/close cycles can therefore accumulate zombie `dscacheutil` processes.

## What changed

Use `Cmd.Run` for the DNS cache flush so the child is waited for and reaped after it exits. The existing best-effort behavior is retained by ignoring the returned error.

## Verification

- `make test`
- `go test .`
- `go vet .`
- `git diff --check`
